### PR TITLE
Use customerId as Kafka partition key

### DIFF
--- a/src/main/scala/com/ovoenergy/delivery/service/kafka/DeliveryFailedEventPublisher.scala
+++ b/src/main/scala/com/ovoenergy/delivery/service/kafka/DeliveryFailedEventPublisher.scala
@@ -5,14 +5,22 @@ import cakesolutions.kafka.KafkaProducer.Conf
 import com.ovoenergy.comms.model.Failed
 import com.ovoenergy.comms.serialisation.Serialisation._
 import com.ovoenergy.delivery.service.kafka.domain.KafkaConfig
-import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.serialization.StringSerializer
+import scala.concurrent.Future
 
 object DeliveryFailedEventPublisher {
 
-  def apply(kafkaConfig: KafkaConfig)(failed: Failed) = {
-    val deliveryFailedProducer = KafkaProducer(Conf(new StringSerializer, avroSerializer[Failed], kafkaConfig.hosts))
-    deliveryFailedProducer.send(new ProducerRecord[String, Failed](kafkaConfig.commFailedTopic, failed))
+  def apply(kafkaConfig: KafkaConfig): Failed => Future[RecordMetadata] = {
+    val producer = KafkaProducer(Conf(new StringSerializer, avroSerializer[Failed], kafkaConfig.hosts))
+
+    (failed: Failed) => {
+      producer.send(new ProducerRecord[String, Failed](
+        kafkaConfig.commFailedTopic, 
+        failed.metadata.customerId,
+        failed
+      ))
+    }
   }
 
 }

--- a/src/main/scala/com/ovoenergy/delivery/service/kafka/DeliveryProgressedEventPublisher.scala
+++ b/src/main/scala/com/ovoenergy/delivery/service/kafka/DeliveryProgressedEventPublisher.scala
@@ -3,15 +3,23 @@ package com.ovoenergy.delivery.service.kafka
 import cakesolutions.kafka.KafkaProducer
 import cakesolutions.kafka.KafkaProducer.Conf
 import com.ovoenergy.comms.model.EmailProgressed
-import com.ovoenergy.delivery.service.kafka.domain.KafkaConfig
-import org.apache.kafka.clients.producer.ProducerRecord
 import com.ovoenergy.comms.serialisation.Serialisation._
+import com.ovoenergy.delivery.service.kafka.domain.KafkaConfig
+import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.serialization.StringSerializer
+import scala.concurrent.Future
 
 object DeliveryProgressedEventPublisher {
 
-  def apply(kafkaConfig: KafkaConfig)(progressed: EmailProgressed) = {
-    val deliveryProgressedProducer  = KafkaProducer(Conf(new StringSerializer, avroSerializer[EmailProgressed], kafkaConfig.hosts))
-    deliveryProgressedProducer.send(new ProducerRecord[String, EmailProgressed](kafkaConfig.emailProgressedTopic, progressed))
+  def apply(kafkaConfig: KafkaConfig): EmailProgressed => Future[RecordMetadata] = {
+    val producer  = KafkaProducer(Conf(new StringSerializer, avroSerializer[EmailProgressed], kafkaConfig.hosts))
+
+    (progressed: EmailProgressed) => {
+      producer.send(new ProducerRecord[String, EmailProgressed](
+        kafkaConfig.emailProgressedTopic, 
+        progressed.metadata.customerId, 
+        progressed
+      ))
+    }
   }
 }

--- a/src/test/scala/com/ovoenergy/delivery/service/kafka/process/EmailDeliveryProcessSpec.scala
+++ b/src/test/scala/com/ovoenergy/delivery/service/kafka/process/EmailDeliveryProcessSpec.scala
@@ -1,4 +1,4 @@
-package com.ovoenergy.delivery.service.Kafka.process
+package com.ovoenergy.delivery.service.kafka.process
 
 import java.time.{Clock, OffsetDateTime, ZoneId}
 import java.util.UUID
@@ -6,7 +6,6 @@ import java.util.UUID
 import akka.Done
 import com.ovoenergy.comms.model._
 import com.ovoenergy.delivery.service.email.mailgun.EmailDeliveryError
-import com.ovoenergy.delivery.service.kafka.process.EmailDeliveryProcess
 import org.scalacheck.Arbitrary
 import org.scalatest.{Failed => _, _}
 import org.scalatest.mockito.MockitoSugar


### PR DESCRIPTION
See ovotech/comms-orchestration#7

Also avoid creating a new Kafka producer for every event