### PR TITLE
Init the Kafka producers lazily

### DIFF
--- a/src/main/scala/com/ovoenergy/delivery/service/kafka/DeliveryFailedEventPublisher.scala
+++ b/src/main/scala/com/ovoenergy/delivery/service/kafka/DeliveryFailedEventPublisher.scala
@@ -12,7 +12,10 @@ import scala.concurrent.Future
 object DeliveryFailedEventPublisher {
 
   def apply(kafkaConfig: KafkaConfig): Failed => Future[RecordMetadata] = {
-    val producer = KafkaProducer(Conf(new StringSerializer, avroSerializer[Failed], kafkaConfig.hosts))
+    // This is only lazy for the sake of the service tests.
+    // We need to construct the producer after the topic has been created,
+    // otherwise the tests randomly fail.
+    lazy val producer = KafkaProducer(Conf(new StringSerializer, avroSerializer[Failed], kafkaConfig.hosts))
 
     (failed: Failed) => {
       producer.send(new ProducerRecord[String, Failed](

--- a/src/main/scala/com/ovoenergy/delivery/service/kafka/DeliveryProgressedEventPublisher.scala
+++ b/src/main/scala/com/ovoenergy/delivery/service/kafka/DeliveryProgressedEventPublisher.scala
@@ -12,7 +12,10 @@ import scala.concurrent.Future
 object DeliveryProgressedEventPublisher {
 
   def apply(kafkaConfig: KafkaConfig): EmailProgressed => Future[RecordMetadata] = {
-    val producer  = KafkaProducer(Conf(new StringSerializer, avroSerializer[EmailProgressed], kafkaConfig.hosts))
+    // This is only lazy for the sake of the service tests.
+    // We need to construct the producer after the topic has been created,
+    // otherwise the tests randomly fail.
+    lazy val producer = KafkaProducer(Conf(new StringSerializer, avroSerializer[EmailProgressed], kafkaConfig.hosts))
 
     (progressed: EmailProgressed) => {
       producer.send(new ProducerRecord[String, EmailProgressed](


### PR DESCRIPTION
This is only to make the service tests more reliable. The test takes
care of creating the Kafka topic, and it appears we need to delay the
init of the `KafkaProducer` until after that has happened. Otherwise the
tests fail randomly.