### PR TITLE
Add retries to the Mailgun API call

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,6 +19,7 @@ object Dependencies {
     "com.ovoenergy"               %% "comms-kafka-serialisation"      % kafkaMessagesVersion,
     "org.typelevel"               %% "cats-core"                      % "0.8.0",
     "com.squareup.okhttp3"         % "okhttp"                         % "3.4.2",
+    "eu.timepit"                  %% "refined"                        % "0.6.1",
     "org.mockito"                  % "mockito-all"                    % "1.10.19"     %   Test,
     "com.github.alexarchambault"  %% "scalacheck-shapeless_1.13"      % "1.1.4"       %   Test,
     "org.scalatest"               %% "scalatest"                      % "3.0.1"       %   Test,

--- a/src/main/resources/common.conf
+++ b/src/main/resources/common.conf
@@ -14,6 +14,8 @@ kafka {
 
 mailgun {
   host = "https://api.mailgun.net"
+  attempts = 5
+  interval = 1 second
 }
 
 akka.kafka.producer {

--- a/src/main/scala/com/ovoenergy/delivery/service/email/mailgun/MailgunClient.scala
+++ b/src/main/scala/com/ovoenergy/delivery/service/email/mailgun/MailgunClient.scala
@@ -7,6 +7,8 @@ import cats.syntax.either._
 import com.ovoenergy.comms.model.EmailStatus.Queued
 import com.ovoenergy.comms.model._
 import com.ovoenergy.delivery.service.logging.LoggingWithMDC
+import com.ovoenergy.delivery.service.util.Retry
+import com.ovoenergy.delivery.service.util.Retry.{Failed, RetryConfig, Succeeded}
 import io.circe.generic.auto._
 import io.circe.generic.extras.semiauto.deriveEnumerationEncoder
 import io.circe.parser._
@@ -18,7 +20,13 @@ import scala.util.{Failure, Success, Try}
 
 object MailgunClient extends LoggingWithMDC {
 
-  case class Configuration(host: String, domain: String, apiKey: String, httpClient: (Request) => Try[Response])(implicit val clock: Clock)
+  case class Configuration(
+                            host: String,
+                            domain: String,
+                            apiKey: String,
+                            httpClient: (Request) => Try[Response],
+                            retryConfig: RetryConfig
+                          )(implicit val clock: Clock)
 
   case class CustomFormData(createdAt: String, customerId: String, traceToken: String, canary: Boolean, commManifest: CommManifest)
 
@@ -28,75 +36,8 @@ object MailgunClient extends LoggingWithMDC {
   implicit val encoder: Encoder[CommType] = deriveEnumerationEncoder[CommType]
 
   def apply(configuration: Configuration)(composedEmail: ComposedEmail): Either[EmailDeliveryError, EmailProgressed] = {
-    case class SendEmailSuccessResponse(id: String, message: String)
-    case class SendEmailFailureResponse(message: String)
-
     val traceToken = composedEmail.metadata.traceToken
-
-    def mapResponseToEither(response: Response, composedEmail: ComposedEmail) = {
-      class Contains(r: Range) {
-        def unapply(i: Int): Boolean = r contains i
-      }
-      val Success = new Contains(200 to 299)
-      val InternalServerError = new Contains(500 to 599)
-
-      val responseBody = response.body().string()
-
-      response.code match {
-        case Success() =>
-          val id = parseResponse[SendEmailSuccessResponse](responseBody).map(_.id).getOrElse("unknown id")
-          logInfo(traceToken, s"Email issued to ${composedEmail.recipient}")
-          Right(EmailProgressed(
-            metadata = Metadata.fromSourceMetadata("delivery-service", composedEmail.metadata)
-              .copy(createdAt = OffsetDateTime.now(configuration.clock).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)),
-            status = Queued,
-            gateway = "Mailgun",
-            gatewayMessageId = Some(id)))
-        case InternalServerError() =>
-          val message = parseResponse[SendEmailFailureResponse](responseBody).map("- " + _.message).getOrElse("")
-          logError(traceToken, s"Error sending email via Mailgun API, Mailgun API internal error: ${response.code} $message")
-          Left(APIGatewayInternalServerError)
-        case 401 =>
-          logError(traceToken, "Error sending email via Mailgun API, authorization with Mailgun API failed")
-          Left(APIGatewayAuthenticationError)
-        case 400 =>
-          val message = parseResponse[SendEmailFailureResponse](responseBody).map("- " + _.message).getOrElse("")
-          logError(traceToken, s"Error sending email via Mailgun API, Bad request $message")
-          Left(APIGatewayBadRequest)
-        case _ =>
-          val message = parseResponse[SendEmailFailureResponse](responseBody).map("- " + _.message).getOrElse("")
-          logError(traceToken, s"Error sending email via Mailgun API, response code: ${response.code} $message")
-          Left(APIGatewayUnspecifiedError)
-      }
-    }
-
-    def buildSendEmailForm(composedEmail: ComposedEmail) = {
-      val form = new FormBody.Builder()
-        .add("from", composedEmail.sender)
-        .add("to", composedEmail.recipient)
-        .add("subject", composedEmail.subject)
-        .add("html", composedEmail.htmlBody)
-        .add("v:custom", buildCustomJson(composedEmail.metadata))
-
-      composedEmail.textBody.fold(form.build())(textBody => form.add("text", textBody).build())
-    }
-
-    def buildCustomJson(metadata: Metadata): String = {
-      CustomFormData(
-        createdAt = OffsetDateTime.now(configuration.clock).format(dtf),
-        customerId = metadata.customerId,
-        traceToken = metadata.traceToken,
-        canary = metadata.canary,
-        commManifest = metadata.commManifest
-      ).asJson.noSpaces
-    }
-
-    def parseResponse[T: Decoder](body: String): Either[Exception, T] = {
-      parse(body) match {
-        case Right(json) => json.as[T]
-        case Left(ex) => Left(ex)
-      }
-    }
+    implicit val clock = configuration.clock
 
     val credentials = Credentials.basic("api", configuration.apiKey)
     val request = new Request.Builder()
@@ -105,11 +46,85 @@ object MailgunClient extends LoggingWithMDC {
       .post(buildSendEmailForm(composedEmail))
       .build()
 
-    configuration.httpClient(request) match {
-      case Success(response) => mapResponseToEither(response, composedEmail)
-      case Failure(ex) =>
-        logError(traceToken, "Error sending email via Mailgun API", ex)
-        Left(ExceptionOccurred)
+    val result = Retry.retry[EmailDeliveryError, EmailProgressed](config = configuration.retryConfig, onFailure = _ => ()) { () =>
+      configuration.httpClient(request) match {
+        case Success(response) => mapResponseToEither(response, composedEmail, traceToken)
+        case Failure(ex) =>
+          logError(traceToken, "Error sending email via Mailgun API", ex)
+          Left(ExceptionOccurred)
+      }
+    }
+    result
+      .leftMap(failed => failed.finalFailure)
+      .map(succeeded => succeeded.result)
+  }
+
+  private def buildSendEmailForm(composedEmail: ComposedEmail)(implicit clock: Clock) = {
+    val form = new FormBody.Builder()
+      .add("from", composedEmail.sender)
+      .add("to", composedEmail.recipient)
+      .add("subject", composedEmail.subject)
+      .add("html", composedEmail.htmlBody)
+      .add("v:custom", buildCustomJson(composedEmail.metadata))
+
+    composedEmail.textBody.fold(form.build())(textBody => form.add("text", textBody).build())
+  }
+
+  private def buildCustomJson(metadata: Metadata)(implicit clock: Clock): String = {
+    CustomFormData(
+      createdAt = OffsetDateTime.now(clock).format(dtf),
+      customerId = metadata.customerId,
+      traceToken = metadata.traceToken,
+      canary = metadata.canary,
+      commManifest = metadata.commManifest
+    ).asJson.noSpaces
+  }
+
+  private def mapResponseToEither(response: Response,
+                                  composedEmail: ComposedEmail,
+                                  traceToken: String)
+                                 (implicit clock: Clock): Either[EmailDeliveryError, EmailProgressed] = {
+    case class SendEmailSuccessResponse(id: String, message: String)
+    case class SendEmailFailureResponse(message: String)
+
+    class Contains(r: Range) {
+      def unapply(i: Int): Boolean = r contains i
+    }
+    val Success = new Contains(200 to 299)
+    val InternalServerError = new Contains(500 to 599)
+
+    val responseBody = response.body().string()
+
+    response.code match {
+      case Success() =>
+        val id = parseResponse[SendEmailSuccessResponse](responseBody).map(_.id).getOrElse("unknown id")
+        logInfo(traceToken, s"Email issued to ${composedEmail.recipient}")
+        Right(EmailProgressed(
+          metadata = Metadata.fromSourceMetadata("delivery-service", composedEmail.metadata)
+            .copy(createdAt = OffsetDateTime.now(clock).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)),
+          status = Queued,
+          gateway = "Mailgun",
+          gatewayMessageId = Some(id)))
+      case InternalServerError() =>
+        val message = parseResponse[SendEmailFailureResponse](responseBody).map("- " + _.message).getOrElse("")
+        logError(traceToken, s"Error sending email via Mailgun API, Mailgun API internal error: ${response.code} $message")
+        Left(APIGatewayInternalServerError)
+      case 401 =>
+        logError(traceToken, "Error sending email via Mailgun API, authorization with Mailgun API failed")
+        Left(APIGatewayAuthenticationError)
+      case 400 =>
+        val message = parseResponse[SendEmailFailureResponse](responseBody).map("- " + _.message).getOrElse("")
+        logError(traceToken, s"Error sending email via Mailgun API, Bad request $message")
+        Left(APIGatewayBadRequest)
+      case _ =>
+        val message = parseResponse[SendEmailFailureResponse](responseBody).map("- " + _.message).getOrElse("")
+        logError(traceToken, s"Error sending email via Mailgun API, response code: ${response.code} $message")
+        Left(APIGatewayUnspecifiedError)
     }
   }
+
+  private def parseResponse[T: Decoder](body: String): Either[Exception, T] = {
+    parse(body).right.flatMap(_.as[T])
+  }
+
 }

--- a/src/main/scala/com/ovoenergy/delivery/service/util/Retry.scala
+++ b/src/main/scala/com/ovoenergy/delivery/service/util/Retry.scala
@@ -1,0 +1,61 @@
+package com.ovoenergy.delivery.service.util
+
+import scala.annotation.tailrec
+import scala.concurrent.duration.FiniteDuration
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric._
+
+object Retry {
+
+  case class Failed[A](attemptsMade: Int, finalFailure: A)
+
+  case class Succeeded[A](result: A, attempts: Int)
+
+  /**
+    * @param attempts The total number of attempts to make, including both the first attempt and any retries.
+    * @param backoff Sleep between attempts. The number of attempts made so far is passed as an argument.
+    */
+  case class RetryConfig(attempts: Int Refined Positive, backoff: Int => Unit)
+
+  /**
+    * Attempt to perform an operation up to a given number of times, then give up.
+    *
+    * @param onFailure A hook that is called after each failure. Useful for logging.
+    * @param f The operation to perform.
+    */
+  def retry[A, B](config: RetryConfig,
+                  onFailure: A => Unit)
+                  (f: () => Either[A, B]): Either[Failed[A], Succeeded[B]] = {
+    @tailrec
+    def rec(attempt: Int): Either[Failed[A], Succeeded[B]] = {
+      f() match {
+        case Right(result) => Right(Succeeded(result, attempt))
+        case Left(failure) =>
+          onFailure(failure)
+          if (attempt == config.attempts.value) {
+            Left(Failed(attempt, failure))
+          } else {
+            config.backoff(attempt)
+            rec(attempt + 1)
+          }
+      }
+    }
+
+    rec(1)
+  }
+
+  object Backoff {
+
+    val retryImmediately = (_: Int) => ()
+
+    def constantDelay(interval: FiniteDuration) = (_: Int) => Thread.sleep(interval.toMillis)
+
+    def exponential(initialInterval: FiniteDuration, exponent: Double) = (attemptsSoFar: Int) => {
+      val interval = initialInterval * Math.pow(exponent, attemptsSoFar - 1)
+      Thread.sleep(interval.toMillis)
+    }
+
+  }
+
+}

--- a/src/test/scala/com/ovoenergy/delivery/service/util/RetrySpec.scala
+++ b/src/test/scala/com/ovoenergy/delivery/service/util/RetrySpec.scala
@@ -1,0 +1,53 @@
+package com.ovoenergy.delivery.service.util
+
+import eu.timepit.refined._
+import eu.timepit.refined.numeric.Positive
+import org.scalatest._
+
+class RetrySpec extends FlatSpec with Matchers {
+  import Retry._
+
+  val onFailure = (_: String) => ()
+
+  it should "succeed if the operation succeeds on the first attempt" in {
+    val result = retry(RetryConfig(refineMV[Positive](5), Backoff.retryImmediately), onFailure)(failNtimesThenSucceed(0))
+    result should be(Right(Retry.Succeeded("yay", 1)))
+  }
+
+  it should "succeed if the operation fails on the first attempt but succeeds on the second" in {
+    val result = retry(RetryConfig(refineMV[Positive](5), Backoff.retryImmediately), onFailure)(failNtimesThenSucceed(1))
+    result should be(Right(Retry.Succeeded("yay", 2)))
+  }
+
+  it should "succeed if the operation succeeds just before we give up" in {
+    val result = retry(RetryConfig(refineMV[Positive](5), Backoff.retryImmediately), onFailure)(failNtimesThenSucceed(4))
+    result should be(Right(Retry.Succeeded("yay", 5)))
+  }
+
+  it should "fail if the operation fails on every attempt" in {
+    val result = retry(RetryConfig(refineMV[Positive](5), Backoff.retryImmediately), onFailure)(failNtimesThenSucceed(5))
+    result should be(Left(Retry.Failed(5, "oops")))
+  }
+
+  it should "work with attempts == 1" in {
+    val config = RetryConfig(refineMV[Positive](1), Backoff.retryImmediately)
+
+    val success = retry(config, onFailure)(failNtimesThenSucceed(0))
+    success should be(Right(Retry.Succeeded("yay", 1)))
+
+    val failure = retry(config, onFailure)(failNtimesThenSucceed(1))
+    failure should be(Left(Retry.Failed(1, "oops")))
+  }
+
+  def failNtimesThenSucceed(n: Int): () => Either[String, String] = {
+    var counter = 0
+    () => {
+      if (counter < n) {
+        counter = counter + 1
+        Left("oops")
+      } else
+        Right("yay")
+    }
+  }
+
+}


### PR DESCRIPTION
Pretty similar to what I did for the orchestrator, except that:

* This time we're using Either instead of Try
* I decided to use the [refined](https://github.com/fthomas/refined) library to make sure the number of attempts passed in as config was positive

Also refactored `MailgunClient` slightly to chop up a huge method.