### PR TITLE
Upgrade comms-kafka-serialisation, circe, cats

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,22 +2,22 @@ import sbt._
 
 object Dependencies {
 
+  val circeVersion = "0.7.0"
 
-
-  def all() = Seq(
+  val all = Seq(
     "com.typesafe.akka"           %% "akka-stream-kafka"              % "0.12",
     "com.typesafe.akka"           %% "akka-slf4j"                     % "2.3.14",
     "ch.qos.logback"               % "logback-classic"                % "1.1.7",
-    "io.circe"                    %% "circe-core"                     % "0.6.0",
-    "io.circe"                    %% "circe-generic-extras"           % "0.6.0",
-    "io.circe"                    %% "circe-parser"                   % "0.6.0",
-    "io.circe"                    %% "circe-generic"                  % "0.6.0",
+    "io.circe"                    %% "circe-core"                     % circeVersion,
+    "io.circe"                    %% "circe-generic-extras"           % circeVersion,
+    "io.circe"                    %% "circe-parser"                   % circeVersion,
+    "io.circe"                    %% "circe-generic"                  % circeVersion,
     "me.moocar"                    % "logback-gelf"                   % "0.2",
     "net.cakesolutions"           %% "scala-kafka-client"             % "0.10.0.0",
     "io.logz.logback"              % "logzio-logback-appender"        % "1.0.11",
     "com.ovoenergy"               %% "comms-kafka-messages"           % "0.0.29",
-    "com.ovoenergy"               %% "comms-kafka-serialisation"      % "1.0",
-    "org.typelevel"               %% "cats-core"                      % "0.8.0",
+    "com.ovoenergy"               %% "comms-kafka-serialisation"      % "2.0",
+    "org.typelevel"               %% "cats-core"                      % "0.9.0",
     "com.squareup.okhttp3"         % "okhttp"                         % "3.4.2",
     "eu.timepit"                  %% "refined"                        % "0.6.1",
     "org.mockito"                  % "mockito-all"                    % "1.10.19"     %   Test,

--- a/src/main/scala/com/ovoenergy/delivery/service/Main.scala
+++ b/src/main/scala/com/ovoenergy/delivery/service/Main.scala
@@ -7,6 +7,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.ovoenergy.comms.model.ComposedEmail
 import com.ovoenergy.comms.serialisation.Serialisation._
+import com.ovoenergy.comms.serialisation.Decoders._
 import com.ovoenergy.delivery.service.email.BlackWhiteList
 import com.ovoenergy.delivery.service.email.mailgun.MailgunClient
 import com.ovoenergy.delivery.service.http.HttpClient
@@ -17,6 +18,7 @@ import com.ovoenergy.delivery.service.logging.LoggingWithMDC
 import com.ovoenergy.delivery.service.util.Retry.RetryConfig
 import com.ovoenergy.delivery.service.util.{Retry, UUIDGenerator}
 import com.typesafe.config.ConfigFactory
+import io.circe.generic.auto._
 import eu.timepit.refined._
 import eu.timepit.refined.numeric.Positive
 

--- a/src/test/scala/com/ovoenergy/delivery/service/ServiceTestIT.scala
+++ b/src/test/scala/com/ovoenergy/delivery/service/ServiceTestIT.scala
@@ -12,6 +12,8 @@ import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializ
 import org.mockserver.client.server.MockServerClient
 import org.mockserver.model.HttpRequest.request
 import com.ovoenergy.comms.serialisation.Serialisation._
+import com.ovoenergy.comms.serialisation.Decoders._
+import io.circe.generic.auto._
 import org.mockserver.matchers.Times
 import org.mockserver.model.HttpResponse.response
 import org.scalacheck.Shapeless._


### PR DESCRIPTION
This means we are now using circe to deserialise JSON-encoded Avro messages